### PR TITLE
Add contribution agents and development docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# hdhr_VCR-AS Contribution Agent
+
+This repository contains the AppleScript sources and assets for the hdhr_VCR smart DVR helper.
+
+## General Guidance
+- Keep `hdhr_VCR.applescript` and `hdhr_VCR_lib.applescript` in the project root; downstream users expect these exact filenames when exporting the app bundle.
+- When you introduce a user-facing change, update `README.md` to reflect the new workflow or capability.
+- If you bump the in-script `Version_local` or library version, add a matching entry to `version.json` (newest release at the top of the list).
+- Screenshots in this repo document the UI flow. If the UI changes meaningfully, refresh the corresponding PNG and keep resolution/aspect consistent with the existing assets.
+
+## Coding Standards
+- Follow the AppleScript conventions captured in `docs/APPLE_SCRIPT_STYLE.md` for any `.applescript` edits.
+- Reuse shared handlers instead of duplicating logic; most string and list helpers already live in `hdhr_VCR_lib.applescript`.
+- Preserve the existing logging pattern so log parsing tools stay compatible.
+
+## Testing Expectations
+- There are no automated tests. Perform the macOS smoke tests described in `docs/TESTING.md` when the behavior of recordings, notifications, or device discovery changes.
+- Document the manual tests you executed in your PR description or summary message.
+
+## Documentation Assets
+- Place any additional developer documentation under `docs/` and link to it from the README when relevant.
+- Keep markdown files wrapped at a readable width (~100 characters) and use GitHub-flavored Markdown features sparingly.
+
+## PR Message
+When preparing a PR summary, include:
+1. A short list of the major feature or bug-fix highlights.
+2. A bullet list of manual tests you performed (referencing `docs/TESTING.md` as needed).
+
+Following these instructions keeps the project aligned with how downstream users compile and run the scripts.

--- a/docs/APPLE_SCRIPT_STYLE.md
+++ b/docs/APPLE_SCRIPT_STYLE.md
@@ -1,0 +1,34 @@
+# AppleScript Style Guide
+
+These conventions capture how the existing scripts are structured. Follow them for any changes to `hdhr_VCR.applescript` or `hdhr_VCR_lib.applescript`.
+
+## Indentation and Formatting
+- Use **hard tabs** for indentation inside handlers. The top-level scope stays unindented.
+- Keep handler declarations flush left: `on handlerName(...)` on one line followed by the body on the next line.
+- Leave a blank line between handlers and between logical sections inside a long handler.
+
+## Handler Structure
+- Define `handlername` at the beginning of every handler. The literal string should match the handler’s purpose (e.g., `set handlername to "setup_logging"`).
+- When a handler accepts a `caller`, compute a context string with `my cm(handlername, caller)` and reuse it for nested calls.
+- Wrap risky logic in `try/on error` blocks. On failure, return either `false` or a `{handlername, errmsg}` tuple, matching the surrounding pattern.
+- When returning lists or records, stick to the existing AppleScript record syntax (`{key:value, ...}`) and maintain consistent key names.
+
+## Logging and Diagnostics
+- Use the logger in the parent script (`logger(...) of ParentScript`) instead of ad-hoc `display dialog` calls for background operations.
+- Populate the logger with the `handlername` and `caller` context so log lines stay searchable.
+- Prefer returning explicit error details and let the caller decide how to handle UI notifications.
+
+## Error Handling Patterns
+- Normalize strings through helpers like `stringToUtf8` before logging them.
+- Use helper utilities in `hdhr_VCR_lib.applescript` (e.g., `stringlistflip`, `emptylist`) rather than duplicating parsing logic.
+- When touching file paths or shell commands, sanitize inputs with the existing helper routines (e.g., `replace_chars`).
+
+## Versioning and Globals
+- Keep global declarations grouped at the top of `hdhr_VCR.applescript`. Add new globals near related entries to preserve readability.
+- If you introduce new configuration constants, ensure they are initialized both in `setup_globals` and persisted through the JSON config.
+
+## User Interaction
+- Maintain the non-blocking pattern: dialogs should have timeouts and avoid leaving the app idle loop paused indefinitely.
+- Leverage the existing emoji icon map (`Icon_record`) for any new UI icons instead of embedding raw characters throughout the code.
+
+Following these conventions keeps the app consistent and makes it easier to diff updates across releases.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,24 @@
+# Testing hdhr_VCR
+
+Automated tests are not available for this AppleScript project. Use the checklist below to validate changes on macOS.
+
+## Preparing the App Bundle
+1. Open `hdhr_VCR.applescript` in **Script Editor**.
+2. Compile the script to confirm it builds cleanly.
+3. Export it as an **Application** with **“Stay open after run handler”** enabled.
+4. Place the exported app in `/Applications` (or a test folder) and launch it.
+
+## Functional Smoke Tests
+- **Device discovery**: Verify that the app lists all reachable HDHomeRun tuners and surfaces their channels.
+- **Guide retrieval**: Ensure the channel guide populates with at least the next four hours of data and thumbnails where available.
+- **Single recording**: Schedule a one-off recording, confirm pre-recording notifications, verify the `.ts` file is created, and inspect the log for errors.
+- **Series recording**: Add a series recording across multiple days. Confirm subsequent entries appear in the “Shows” list with accurate next-run times.
+- **Manual add**: Schedule a recording using decimal time. Confirm the time normalizes to the correct start boundary.
+- **Disk checks**: Trigger a recording on a volume with limited space and watch for the warning/abort logic tied to `Max_disk_percentage`.
+- **Quit flow**: While recording, attempt to quit the app. Validate the prompts to continue, cancel, or leave recordings running.
+
+## Logging and Telemetry
+- Review `~/Library/Logs/hdhr_VCR.log` for new warnings or errors.
+- If debugging, switch the logger level to include `DEBUG`/`TRACE` and confirm that sensitive data (API keys, user paths) is not leaked.
+
+Document the macOS version, HDHomeRun model, and steps executed when recording manual test results for a PR.


### PR DESCRIPTION
## Summary
- add a root `AGENTS.md` that documents contribution, testing, and release expectations for the AppleScript sources
- document the existing AppleScript code style and manual testing checklist under `docs/`

## Testing
- not run (requires macOS environment to exercise Script Editor workflow)


------
https://chatgpt.com/codex/tasks/task_e_68cdc0d3e8308324a8fc34224e150327