### PR TITLE
Adjust git config for AppleScript workflows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 * text=auto
-*.applescript  diff=astextplain
+
+# Normalize source AppleScript files
+*.applescript text eol=lf linguist-language=AppleScript
+
+# Offer readable diffs for compiled script artifacts
+*.scpt diff=astextplain
+*.scptd diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
-
+# macOS Finder metadata
 .DS_Store
+
+# Script Editor export scratchpad
 whatsnew.txt
+
+# AppleScript build artifacts
+*.scpt
+*.scptd
+*.app
+*.app/
+
+# Local packaging leftovers
+*.dmg
+*.pkg


### PR DESCRIPTION
## Summary
- expand `.gitignore` to cover compiled AppleScript exports and packaging remnants
- refine `.gitattributes` so AppleScript sources stay normalized while compiled scripts still diff as text

## Testing
- not run (config-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ce6078412083249c7823c73a49fce0