### PR TITLE
chore: trigger version workflow on master

### DIFF
--- a/.github/workflows/update-version-json.yml
+++ b/.github/workflows/update-version-json.yml
@@ -1,0 +1,25 @@
+name: Auto update version metadata
+
+on:
+  push:
+    branches:
+      - master  # Trigger when commits land on the default branch
+    paths:  # Only run when the primary AppleScript sources change
+      - "hdhr_VCR.applescript"
+      - "hdhr_VCR_lib.applescript"
+
+permissions:
+  contents: write
+
+jobs:
+  version_metadata:
+    if: github.event.deleted == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Placeholder
+        run: echo "Update version.json workflow placeholder"


### PR DESCRIPTION
## Summary
- add update-version-json workflow that runs when master receives pushes
- limit the workflow to AppleScript source changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1ef7f4fac8324979e933404855803