### PR TITLE
Document AppleScript comment handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@ This repository contains the AppleScript sources and assets for the hdhr_VCR sma
 - If you bump the in-script `Version_local` or library version, add a matching entry to `version.json` (newest release at the top of the list).
 - Screenshots in this repo document the UI flow. If the UI changes meaningfully, refresh the corresponding PNG and keep resolution/aspect consistent with the existing assets.
 
+## Comment Handling
+- Treat any text that follows a `#` character on a line in the AppleScript sources as a comment.
+- Treat any code enclosed by `(*` and `*)` as a block comment.
+- Ignore modifications limited to these comments when deciding whether `CHANGELOG.md` or `version.json` require updates.
+
 ## Coding Standards
 - Follow the AppleScript conventions captured in `docs/APPLE_SCRIPT_STYLE.md` for any `.applescript` edits.
 - Reuse shared handlers instead of duplicating logic; most string and list helpers already live in `hdhr_VCR_lib.applescript`.

--- a/docs/handler.md
+++ b/docs/handler.md
@@ -1,14 +1,17 @@
-# Handler Reference
+Handler Reference
+=================
 
-## Overview
+Overview
+--------
 The hdhr_VCR project packages two collaborating AppleScript files that turn an HDHomeRun tuner into a lightweight DVR. The `hdhr_VCR.applescript` file hosts the main application logic and user interface flow, while `hdhr_VCR_lib.applescript` provides reusable helpers for date math, logging, SeriesID handling, and other utilities that keep the core script tidy.
 
-## Purpose
+Purpose
+-------
 This guide gives a formatted inventory of every handler in both scripts, the inputs they expect, the values they return, and how the surrounding run loop treats `missing value` results. AppleScript commonly uses `missing value` to indicate "no response"; wherever a handler returns it, the table explains whether the application's main loop, idle loop, or other retry logic will revisit the handler.
 
 ---
 
-## `hdhr_VCR.applescript`
+<h2><code>hdhr_VCR.applescript</code></h2>
 
 | Handler | Inputs | Outputs | Notes & Missing Value Handling |
 | --- | --- | --- | --- |
@@ -95,7 +98,7 @@ This guide gives a formatted inventory of every handler in both scripts, the inp
 
 ---
 
-## `hdhr_VCR_lib.applescript`
+<h2><code>hdhr_VCR_lib.applescript</code></h2>
 
 | Handler | Inputs | Outputs | Notes & Missing Value Handling |
 | --- | --- | --- | --- |


### PR DESCRIPTION
## Summary
- document how `#` and `(* ... *)` comments should be treated in the contribution guidelines
- remove comment-style markers from the handler reference headings so the documentation matches the new guidance

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d76f27104483249ac640ad1840fae5