### PR TITLE
Automate archiving Codex requests on merge

### DIFF
--- a/.github/workflows/archive-codex-requests.yml
+++ b/.github/workflows/archive-codex-requests.yml
@@ -1,0 +1,129 @@
+name: Archive Codex requests
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  pull-requests: read
+  contents: read
+  issues: write
+
+jobs:
+  archive:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Archive referenced Codex requests
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CODEX_ARCHIVE_TOKEN || github.token }}
+          script: |
+            const body = context.payload.pull_request.body ?? "";
+            const pattern = /Codex Request:\s*(https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/issues\/\d+)/gi;
+            const matches = [...body.matchAll(pattern)];
+
+            if (matches.length === 0) {
+              core.info("No Codex request references detected in the pull request body.");
+              return;
+            }
+
+            const requestsByRepo = new Map();
+
+            for (const match of matches) {
+              const issueUrl = match[1];
+              const parsed = issueUrl.match(/https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/issues\/(\d+)/i);
+
+              if (!parsed) {
+                core.warning(`Unable to parse Codex request reference: ${issueUrl}`);
+                continue;
+              }
+
+              const [, owner, repo, issueNumberRaw] = parsed;
+              const issueNumber = Number.parseInt(issueNumberRaw, 10);
+
+              if (Number.isNaN(issueNumber)) {
+                core.warning(`Skipping Codex request with invalid issue number from ${issueUrl}`);
+                continue;
+              }
+
+              const key = `${owner}/${repo}`;
+              if (!requestsByRepo.has(key)) {
+                requestsByRepo.set(key, { owner, repo, issues: new Set() });
+              }
+
+              requestsByRepo.get(key).issues.add(issueNumber);
+            }
+
+            if (requestsByRepo.size === 0) {
+              core.info("No valid Codex request references found after parsing.");
+              return;
+            }
+
+            async function ensureArchivedLabel(owner, repo) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: "archived" });
+                core.info(`'archived' label already present in ${owner}/${repo}.`);
+              } catch (error) {
+                if (error.status === 404) {
+                  try {
+                    await github.rest.issues.createLabel({
+                      owner,
+                      repo,
+                      name: "archived",
+                      color: "BFD4F2",
+                      description: "Codex request has been archived after merge"
+                    });
+                    core.info(`Created 'archived' label in ${owner}/${repo}.`);
+                  } catch (createError) {
+                    core.warning(`Unable to create 'archived' label in ${owner}/${repo}: ${createError.message}`);
+                  }
+                } else {
+                  core.warning(`Failed to verify 'archived' label in ${owner}/${repo}: ${error.message}`);
+                }
+              }
+            }
+
+            for (const entry of requestsByRepo.values()) {
+              const { owner, repo, issues } = entry;
+
+              await ensureArchivedLabel(owner, repo);
+
+              for (const issueNumber of issues) {
+                core.info(`Archiving Codex request ${owner}/${repo}#${issueNumber}.`);
+
+                try {
+                  await github.rest.issues.update({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    state: "closed"
+                  });
+                } catch (error) {
+                  core.warning(`Unable to close ${owner}/${repo}#${issueNumber}: ${error.message}`);
+                  continue;
+                }
+
+                try {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    labels: ["archived"]
+                  });
+                } catch (error) {
+                  core.warning(`Unable to apply 'archived' label to ${owner}/${repo}#${issueNumber}: ${error.message}`);
+                }
+
+                try {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    body: `This Codex request was automatically archived after ${context.payload.pull_request.html_url} was merged.`
+                  });
+                } catch (error) {
+                  core.warning(`Unable to add archival comment to ${owner}/${repo}#${issueNumber}: ${error.message}`);
+                }
+              }
+            }

--- a/README.md
+++ b/README.md
@@ -103,3 +103,11 @@ _See below for a visual walkthrough of the process:_
 
 ```applescript
 {show_title:"Example", show_time:16, ...}
+```
+
+---
+
+## Maintainer Automation
+
+See [docs/CODEX_REQUESTS.md](docs/CODEX_REQUESTS.md) for details on the workflow
+that archives Codex requests automatically after a pull request merges.

--- a/docs/CODEX_REQUESTS.md
+++ b/docs/CODEX_REQUESTS.md
@@ -1,0 +1,37 @@
+# Codex Request Archival Process
+
+This repository now archives Codex request issues automatically whenever a pull
+request that resolves them is merged. The automation relies on a lightweight
+convention in the pull request description, so maintainers should follow the
+steps below when submitting work that came from a Codex request.
+
+## Referencing the Codex request
+
+Include a line in the pull request description using the following format:
+
+```
+Codex Request: https://github.com/<owner>/<repository>/issues/<number>
+```
+
+You may reference more than one request by adding additional lines that follow
+the same `Codex Request:` prefix. The workflow parses these URLs after the pull
+request merges, closes the linked issues, and applies an `archived` label to
+highlight that the request is complete.
+
+## Optional cross-repository support
+
+By default, the workflow uses the standard `GITHUB_TOKEN`, which can manage
+issues within this repository. If your Codex requests live in a separate
+repository, add a personal access token with the necessary permissions as the
+`CODEX_ARCHIVE_TOKEN` repository secret. The workflow will automatically fall
+back to that token when available and attempt to archive the linked requests in
+that external repository as well.
+
+## Troubleshooting
+
+- **Label missing:** The workflow creates the `archived` label if it does not
+  already exist. If label creation fails (for example, due to missing
+  permissions), the issue will still close but remain unlabelled.
+- **Malformed URL:** If the URL after `Codex Request:` is not a standard GitHub
+  issue link, the workflow skips it. Edit the merged pull request description
+  to fix the URL and re-run the workflow manually from the Actions tab.


### PR DESCRIPTION
## Summary
- add a pull-request-closed workflow that closes, labels, and comments on linked Codex request issues
- document the Codex request reference format and optional secret configuration for the automation
- link the maintainer documentation from the README for easy discovery

## Testing
- not run (workflow and documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68df4081ede08324b158c3fd6195354c