### PR TITLE
Move AppleScript coding standards from AGENTS.md into style guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,6 @@ This repository contains the AppleScript sources and assets for the hdhr_VCR sma
 
 ## Coding Standards
 - Follow the AppleScript conventions captured in `docs/APPLE_SCRIPT_STYLE.md` for any `.applescript` edits.
-- Reuse shared handlers instead of duplicating logic; most string and list helpers already live in `hdhr_VCR_lib.applescript`.
-- Preserve the existing logging pattern so log parsing tools stay compatible.
-- When one handler calls another within the same script, prefix it with `my`; when calling across scripts, use `of ParentScript`
-  or `of LibScript` as appropriate.
 
 ## Testing Expectations
 - There are no automated tests. Perform the macOS smoke tests described in `docs/TESTING.md` when the behavior of recordings, notifications, or device discovery changes.

--- a/docs/APPLE_SCRIPT_STYLE.md
+++ b/docs/APPLE_SCRIPT_STYLE.md
@@ -9,6 +9,9 @@ These conventions capture how the existing scripts are structured. Follow them f
 
 ## Handler Structure
 - Define `handlername` at the beginning of every handler. The literal string should match the handler’s purpose (e.g., `set handlername to "setup_logging"`).
+- Reuse shared handlers instead of duplicating logic; most string and list helpers already live in `hdhr_VCR_lib.applescript`.
+- When one handler calls another within the same script, prefix it with `my`; when calling across scripts, use `of ParentScript`
+  or `of LibScript` as appropriate.
 - When a handler accepts a `caller`, compute a context string with `my cm(handlername, caller)` and reuse it for nested calls.
 - Wrap risky logic in `try/on error` blocks. On failure, return either `false` or a `{handlername, errmsg}` tuple, matching the surrounding pattern.
 - When returning lists or records, stick to the existing AppleScript record syntax (`{key:value, ...}`) and maintain consistent key names.
@@ -17,6 +20,7 @@ These conventions capture how the existing scripts are structured. Follow them f
 - Use the logger in the parent script (`logger(...) of ParentScript`) instead of ad-hoc `display dialog` calls for background operations.
 - Populate the logger with the `handlername` and `caller` context so log lines stay searchable.
 - Prefer returning explicit error details and let the caller decide how to handle UI notifications.
+- Preserve the existing logging pattern so log parsing tools stay compatible.
 
 ## Error Handling Patterns
 - Normalize strings through helpers like `stringToUtf8` before logging them.
@@ -25,6 +29,7 @@ These conventions capture how the existing scripts are structured. Follow them f
 
 ## Versioning and Globals
 - Keep global declarations grouped at the top of `hdhr_VCR.applescript`. Add new globals near related entries to preserve readability.
+- Treat variables that start with a capital letter as globals.
 - If you introduce new configuration constants, ensure they are initialized both in `setup_globals` and persisted through the JSON config.
 
 ## User Interaction


### PR DESCRIPTION
### Motivation
- Centralize AppleScript coding conventions in the dedicated style guide so guidance is not duplicated across contributor notes.
- Keep `AGENTS.md` focused on high-level contributor orientation and a pointer to detailed language rules.
- Make it clearer where to find authoritative rules for handler structure, cross-script calls, and logging so contributors follow existing patterns.

### Description
- Remove inline AppleScript coding bullets from `AGENTS.md` and leave a single pointer to `docs/APPLE_SCRIPT_STYLE.md` for `.applescript` edits. 
- Add reuse-of-handlers guidance and cross-script call prefixing (`my`, `of ParentScript`, `of LibScript`) to `docs/APPLE_SCRIPT_STYLE.md` under the Handler Structure section. 
- Add the logging-preservation note to the Logging and Diagnostics section of `docs/APPLE_SCRIPT_STYLE.md`. 
- Add the rule that variables starting with a capital letter are globals to the Versioning and Globals section of `docs/APPLE_SCRIPT_STYLE.md`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69705973d5448324bfe31e9914442e09)