### PR TITLE
Document handler sync requirement and YYMMDD version naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,13 @@ This repository contains the AppleScript sources and assets for the hdhr_VCR sma
 - Keep `hdhr_VCR.applescript` and `hdhr_VCR_lib.applescript` in the project root; downstream users expect these exact filenames when exporting the app bundle.
 - When you introduce a user-facing change, update `README.md` to reflect the new workflow or capability.
 - If you bump the in-script `Version_local` or library version, add a matching entry to `version.json` (newest release at the top of the list).
-- Screenshots in this repo document the UI flow. If the UI changes meaningfully, refresh the corresponding PNG and keep resolution/aspect consistent with the existing assets.
+- Use YYMMDD for version naming (for example, `250919`) across `version.json` and
+  `CHANGELOG.md`.
+- Screenshots in this repo document the UI flow. If the UI changes meaningfully,
+  refresh the corresponding PNG and keep resolution/aspect consistent with the
+  existing assets.
+- If you add, remove, or change handlers in either AppleScript file, update
+  `docs/handler.md` to keep the handler reference in sync.
 
 ## Comment Handling
 - Treat any text that follows a `#` character on a line in the AppleScript sources as a comment.

--- a/docs/handler.md
+++ b/docs/handler.md
@@ -1,6 +1,12 @@
 Handler Reference
 =================
 
+Maintenance
+-----------
+Update this reference whenever handlers are added, removed, or modified in
+`hdhr_VCR.applescript` or `hdhr_VCR_lib.applescript` so the inputs/returns stay
+accurate.
+
 Overview
 --------
 The hdhr_VCR project packages two collaborating AppleScript files that turn an HDHomeRun tuner into a lightweight DVR. The
@@ -201,4 +207,3 @@ The `logger` handler is implemented locally to keep log writes within the applic
 | `isSystemShutdown` | `caller` | `boolean` or `{…}` | Detects whether macOS is in the middle of shutting down. |
 | `corrupt_showinfo` | `caller` | `missing value` | Logging hook that fires when saved show data looks corrupted. |
 | `isModifierKeyPressed` | `caller`, `checkKey`, `desc` | `record` or `{…}` | Reports modifier key state for UI shortcuts. |
-


### PR DESCRIPTION
### Motivation
- Ensure the handler reference remains accurate by requiring updates to `docs/handler.md` whenever AppleScript handlers change.
- Standardize release version naming to `YYMMDD` across `version.json` and `CHANGELOG.md` to remove ambiguity.
- Improve readability of `AGENTS.md` by normalizing line wrapping and guidance layout.

### Description
- Add guidance to `AGENTS.md` to use `YYMMDD` (for example, `250919`) for version naming across `version.json` and `CHANGELOG.md`.
- Add guidance to `AGENTS.md` requiring updates to `docs/handler.md` when handlers are added, removed, or changed in `hdhr_VCR.applescript` or `hdhr_VCR_lib.applescript`.
- Insert a `Maintenance` section at the top of `docs/handler.md` instructing maintainers to update the handler reference to keep inputs/returns accurate.
- Perform minor formatting and line-wrapping cleanup in `AGENTS.md` for consistent presentation.

### Testing
- No automated tests were run because this is a documentation-only change.
- Manual macOS smoke tests are documented in `docs/TESTING.md` and should be used when related runtime behavior changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69705ba2a5308324a4711581d0eb8842)